### PR TITLE
demaion/polyfill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ __pycache__/
 
 .pytest_cache/
 .conda_rhppandas/
+.vscode/
 
 .coverage

--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,4 @@ dependencies:
   - pip
   - pip:
     # Use pip to install rhp from dev branch of git repo
-    - git+https://github.com/manaakiwhenua/rhealpixdggs-py.git@demaion/raster2dggs
+    - git+https://github.com/manaakiwhenua/rhealpixdggs-py.git@demaion/polyfill

--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,4 @@ dependencies:
   - pip
   - pip:
     # Use pip to install rhp from dev branch of git repo
-    - git+https://github.com/manaakiwhenua/rhealpixdggs-py.git@demaion/polyfill
+    - git+https://github.com/manaakiwhenua/rhealpixdggs-py.git

--- a/rhppandas/__init__.py
+++ b/rhppandas/__init__.py
@@ -1,1 +1,3 @@
+from . import rhppandas
+
 __version__: str = "0.1.0"

--- a/rhppandas/__init__.py
+++ b/rhppandas/__init__.py
@@ -1,3 +1,1 @@
 from . import rhppandas
-
-__version__: str = "0.1.0"

--- a/rhppandas/rhppandas.py
+++ b/rhppandas/rhppandas.py
@@ -18,6 +18,9 @@ class rHPAccessor:
     Shamelessly appropriated from equivalent class in h3pandas package
 
     The h3pandas repo is found here: https://github.com/DahnJ/H3-Pandas
+
+    TODO: - Support both plane and sphere (currently hardwired to sphere)
+          - Support user defined instance of underlying dggs (currently hardwired to WGS84_003)
     """
 
     def __init__(self, df: pd.DataFrame) -> None:
@@ -128,7 +131,9 @@ class rHPAccessor:
         """
         return self._apply_index_assign(rhp_py.rhp_is_valid, "rhp_is_valid")
 
-    def k_ring(self, k: int = 1, explode: bool = False, verbose=True) -> AnyDataFrame:
+    def k_ring(
+        self, k: int = 1, explode: bool = False, verbose: bool = True
+    ) -> AnyDataFrame:
         """
         Parameters
         ----------
@@ -194,22 +199,66 @@ class rHPAccessor:
 
     def rhp_to_center_child(self, resolution: int = None) -> AnyDataFrame:
         """
-        Adds a column 'rhp_center_child' with the address of the central child
-        cell at the requested resolution to the dataframe.
+        Adds a column 'rhp_center_child' with the address of the central child cell at the
+        requested resolution to the dataframe.
         ----------
         Parameters
         ----------
         resolution : int or None
-            rHEALPix resolution. If none, then returns the child of resolution
-            directly below that of each rHEALPix cell
+            rHEALPix resolution. If none, then returns the child of resolution directly
+            below that of each rHEALPix cell
         """
         return self._apply_index_assign(
             wrapped_partial(rhp_py.rhp_to_center_child, res=resolution),
             "rhp_center_child",
         )
 
-    def polyfill(self) -> AnyDataFrame:
-        raise NotImplementedError()
+    def polyfill(
+        self,
+        resolution: int,
+        explode: bool = False,
+        compress: bool = False,
+        verbose: bool = True,
+    ) -> AnyDataFrame:
+        """
+        Adds a column 'rhp_polyfill' listing the cells where the cell centroid is
+        contained within the input (multi)polygon geometry.
+        Relies on the dataframe having a 'geometry' column with shapely Polygon or
+        MultiPolygon entries.
+        ----------
+        Parameters
+        ----------
+        resolution : int
+            rHEALPix resolution
+        explode : bool
+            If True, will explode the resulting list vertically.
+            All other columns' values are copied.
+            Default: False
+        compress : bool
+            If True, will group cells making up a parent cell and use the address of the
+            parent cell instead of the individual child addresses.
+            Default: False
+        """
+
+        # Need to wrap polyfill for each dataframe row so we can call it with geometry
+        def func(row):
+            if not "geometry" in row.keys():
+                return None
+            else:
+                return rhp_py.polyfill(
+                    row.geometry, resolution, False, compress, verbose
+                )
+
+        # Polyfill cell sets for each row
+        result = self._df.apply(func, axis=1)
+
+        if not explode:
+            assign_args = {"rhp_polyfill": result}
+            return self._df.assign(**assign_args)
+
+        result = result.explode().to_frame("rhp_polyfill")
+
+        return self._df.join(result)
 
     def cell_area(self, unit: Literal["km^2", "m^2"] = "km^2") -> AnyDataFrame:
         """
@@ -318,14 +367,6 @@ class rHPAccessor:
         )
 
         return grouped.rhp.rhp_to_geo_boundary() if return_geometry else grouped
-
-    # TODO: placeholder, find out if rhp needs that function
-    # def k_ring_smoothing(self) -> AnyDataFrame:
-    #    pass
-
-    # TODO: placeholder, find out if rhp needs that function
-    # def weighted_square_ring(self):
-    #    pass
 
     def polyfill_resample(self) -> AnyDataFrame:
         raise NotImplementedError()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from os import path
 
-from rhppandas import __version__
+__version__: str = "0.1.0"
 
 # read the contents of README file
 this_directory = path.abspath(path.dirname(__file__))

--- a/tests/test_rhppandas.py
+++ b/tests/test_rhppandas.py
@@ -40,8 +40,16 @@ def basic_geodataframe_with_values(basic_geodataframe):
 
 @pytest.fixture
 def basic_geodataframe_polygon():
+    """GeoDataFrame with POLYGON geometry"""
     geom = box(0, 0, 1, 1)
     return gpd.GeoDataFrame(geometry=[geom], crs="epsg:4326")
+
+
+@pytest.fixture
+def basic_geodataframe_polygons():
+    """GeoDataFrame with POLYGON geometries"""
+    geoms = [box(14, 50, 15, 51), box(14, 50, 15, 52)]
+    return gpd.GeoDataFrame(geometry=geoms, crs="epsg:4326")
 
 
 @pytest.fixture
@@ -404,17 +412,14 @@ class TestPolyfill:
         assert set(result["rhp_polyfill"]) == expected_indices
         assert not result["val"].isna().any()
 
-    # def test_polyfill_explode_unequal_lengths(self, basic_geodataframe_polygons):
-    #     expected_indices = {
-    #         "83754efffffffff",
-    #         "83756afffffffff",
-    #         "83754efffffffff",
-    #         "837541fffffffff",
-    #         "83754cfffffffff",
-    #     }
-    #     result = basic_geodataframe_polygons.rhp.polyfill(3, explode=True)
-    #     assert len(result) == 5
-    #     assert set(result["rhp_polyfill"]) == expected_indices
+    def test_polyfill_explode_unequal_lengths(self, basic_geodataframe_polygons):
+        expected_indices = {
+            "N2085",
+            "N2160",
+        }
+        result = basic_geodataframe_polygons.rhp.polyfill(4, explode=True)
+        assert len(result) == 3
+        assert set(result["rhp_polyfill"]) == expected_indices
 
 
 class TestCellArea:

--- a/tests/test_rhppandas.py
+++ b/tests/test_rhppandas.py
@@ -71,7 +71,7 @@ def rhp_dataframe_with_values():
 def rhp_geodataframe_with_values(rhp_dataframe_with_values):
     """GeoDataFrame with resolution 9 rHEALPix index, values, and cell geometries"""
     geometry = [
-        Polygon(rhp_py.rhp_to_geo_boundary(h, True))
+        Polygon(rhp_py.rhp_to_geo_boundary(h, True, False))
         for h in rhp_dataframe_with_values.index
     ]
     return gpd.GeoDataFrame(
@@ -314,7 +314,107 @@ class TestRhpToCenterChild:
 
 
 class TestPolyfill:
-    pass
+    def test_empty_polyfill(self, rhp_geodataframe_with_values):
+        expected = rhp_geodataframe_with_values.assign(
+            rhp_polyfill=[set(), set(), set()]
+        )
+        result = rhp_geodataframe_with_values.rhp.polyfill(1)
+        assert_geodataframe_equal(expected, result)
+
+    def test_polyfill(self, rhp_geodataframe_with_values):
+        expected_cells = [
+            {
+                "N2160556110",
+                "N2160556111",
+                "N2160556112",
+                "N2160556113",
+                "N2160556114",
+                "N2160556115",
+                "N2160556116",
+                "N2160556117",
+                "N2160556118",
+            },
+            {
+                "N2160556120",
+                "N2160556121",
+                "N2160556122",
+                "N2160556123",
+                "N2160556124",
+                "N2160556125",
+                "N2160556126",
+                "N2160556127",
+                "N2160556128",
+            },
+            {
+                "N2160556150",
+                "N2160556151",
+                "N2160556152",
+                "N2160556153",
+                "N2160556154",
+                "N2160556155",
+                "N2160556156",
+                "N2160556157",
+                "N2160556158",
+            },
+        ]
+        expected = rhp_geodataframe_with_values.assign(rhp_polyfill=expected_cells)
+        result = rhp_geodataframe_with_values.rhp.polyfill(10)
+        assert_geodataframe_equal(expected, result)
+
+    def test_polyfill_explode(self, rhp_geodataframe_with_values):
+        expected_indices = set().union(
+            *[
+                [
+                    "N2160556110",
+                    "N2160556111",
+                    "N2160556112",
+                    "N2160556113",
+                    "N2160556114",
+                    "N2160556115",
+                    "N2160556116",
+                    "N2160556117",
+                    "N2160556118",
+                ],
+                [
+                    "N2160556120",
+                    "N2160556121",
+                    "N2160556122",
+                    "N2160556123",
+                    "N2160556124",
+                    "N2160556125",
+                    "N2160556126",
+                    "N2160556127",
+                    "N2160556128",
+                ],
+                [
+                    "N2160556150",
+                    "N2160556151",
+                    "N2160556152",
+                    "N2160556153",
+                    "N2160556154",
+                    "N2160556155",
+                    "N2160556156",
+                    "N2160556157",
+                    "N2160556158",
+                ],
+            ]
+        )
+        result = rhp_geodataframe_with_values.rhp.polyfill(10, explode=True)
+        assert len(result) == len(rhp_geodataframe_with_values) * 9
+        assert set(result["rhp_polyfill"]) == expected_indices
+        assert not result["val"].isna().any()
+
+    # def test_polyfill_explode_unequal_lengths(self, basic_geodataframe_polygons):
+    #     expected_indices = {
+    #         "83754efffffffff",
+    #         "83756afffffffff",
+    #         "83754efffffffff",
+    #         "837541fffffffff",
+    #         "83754cfffffffff",
+    #     }
+    #     result = basic_geodataframe_polygons.rhp.polyfill(3, explode=True)
+    #     assert len(result) == 5
+    #     assert set(result["rhp_polyfill"]) == expected_indices
 
 
 class TestCellArea:
@@ -375,15 +475,6 @@ class TestRhpToParentAggregate:
         expected = pd.DataFrame({"val": [1 + 2 + 5]}, index=index)
 
         pd.testing.assert_frame_equal(expected, result)
-
-
-# TODO: placeholder, find out if rhp needs that test class
-# class TestKRingSmoothing:
-#    pass
-
-# TODO: placeholder, find out if rhp needs that test class
-# class TestWeightedCellRing:
-#    pass
 
 
 class TestPolyfillResample:


### PR DESCRIPTION
Wires up dataframes and geodataframes to the new polyfill functionality in rhealpixdggs.rhp_wrappers.py, updated automated tests as well.

I've also removed some commented sections with function signatures that don't have an implementation date. Those functions are based on the advanced interface in h3pandas and would (mostly) use existing features from rhealpixdggs.rhp_wrappers.py in new ways. Having them commented out in the list of functions just adds code debris and could potentially be confusing at this stage. They should be added back into the wrapper when they're ready to be implemented.

Not implemented:
- Boolean flag `plane` - everything happens on the sphere for now
- DGGS instance as a parameter - everything assumes `WGS84_003`

Not in scope:
- Linetrace
- Advanced interface as implemented in h3pandas (k-ring smoothing, polyfill resampling)