### PR TITLE
demaion/polyfill resample

### DIFF
--- a/rhppandas/rhppandas.py
+++ b/rhppandas/rhppandas.py
@@ -7,6 +7,7 @@ import geopandas as gpd
 
 import rhealpixdggs.rhp_wrappers as rhp_py
 
+from .util.const import *
 from .util.functools import wrapped_partial
 
 AnyDataFrame = Union[pd.DataFrame, gpd.GeoDataFrame]
@@ -26,6 +27,7 @@ class rHPAccessor:
     def __init__(self, df: pd.DataFrame) -> None:
         self._df = df
 
+    # RHP wrapper API
     def geo_to_rhp(
         self,
         resolution: int,
@@ -68,7 +70,7 @@ class rHPAccessor:
         ]
 
         # Add results to DataFrame
-        colname = f"rhp_{resolution:02}"
+        colname = f"{COLUMNS['prefix']}{resolution:02}"
         assign_arg = {colname: rhpaddresses}
         df = self._df.assign(**assign_arg)
         if set_index:
@@ -89,7 +91,7 @@ class rHPAccessor:
         """
         return self._apply_index_assign(
             wrapped_partial(rhp_py.rhp_to_geo, geo_json=True, plane=False),
-            "geometry",
+            COLUMNS["geometry"],
             lambda x: shapely.geometry.Point(x),
             lambda x: gpd.GeoDataFrame(
                 x, crs="epsg:4326"
@@ -105,7 +107,7 @@ class rHPAccessor:
         """
         return self._apply_index_assign(
             wrapped_partial(rhp_py.rhp_to_geo_boundary, geo_json=True, plane=False),
-            "geometry",
+            COLUMNS["geometry"],
             lambda x: shapely.geometry.Polygon(x),
             lambda x: gpd.GeoDataFrame(
                 x, crs="epsg:4326"
@@ -116,20 +118,22 @@ class rHPAccessor:
         """
         Adds a column 'rhp_resolution' with the resolution of each cell to the dataframe.
         """
-        return self._apply_index_assign(rhp_py.rhp_get_resolution, "rhp_resolution")
+        return self._apply_index_assign(
+            rhp_py.rhp_get_resolution, COLUMNS["resolution"]
+        )
 
     def rhp_get_base_cell(self) -> AnyDataFrame:
         """
         Adds a column 'rhp_base_cell' with the resolution 0 parent cell to the dataframe.
         """
-        return self._apply_index_assign(rhp_py.rhp_get_base_cell, "rhp_base_cell")
+        return self._apply_index_assign(rhp_py.rhp_get_base_cell, COLUMNS["base_cell"])
 
     def rhp_is_valid(self) -> AnyDataFrame:
         """
         Adds a column 'rhp_is_valid' indicating if the cell addresses are valid rHEALPix
         addresses or not.
         """
-        return self._apply_index_assign(rhp_py.rhp_is_valid, "rhp_is_valid")
+        return self._apply_index_assign(rhp_py.rhp_is_valid, COLUMNS["is_valid"])
 
     def k_ring(
         self, k: int = 1, explode: bool = False, verbose: bool = True
@@ -154,7 +158,7 @@ class rHPAccessor:
             warn(str.format(rhp_py.CELL_RING_WARNING, "k"))
 
         func = wrapped_partial(rhp_py.k_ring, k=k, verbose=False)
-        column_name = "rhp_k_ring"
+        column_name = COLUMNS["k_ring"]
         if explode:
             return self._apply_index_explode(func, column_name, list)
         return self._apply_index_assign(func, column_name, list)
@@ -176,7 +180,7 @@ class rHPAccessor:
             warn(str.format(rhp_py.CELL_RING_WARNING, "cell"))
 
         func = wrapped_partial(rhp_py.cell_ring, k=k, verbose=False)
-        column_name = "rhp_cell_ring"
+        column_name = COLUMNS["cell_ring"]
         if explode:
             return self._apply_index_explode(func, column_name, list)
         return self._apply_index_assign(func, column_name, list)
@@ -191,7 +195,11 @@ class rHPAccessor:
         resolution : int or None
             rHEALPix resolution. If None, then returns the direct parent of each rHEALPix cell.
         """
-        column = f"rhp_{resolution:02}" if resolution is not None else "rhp_parent"
+        column = (
+            f"{COLUMNS['prefix']}{resolution:02}"
+            if resolution is not None
+            else COLUMNS["parent"]
+        )
 
         return self._apply_index_assign(
             wrapped_partial(rhp_py.rhp_to_parent, res=resolution), column
@@ -210,7 +218,7 @@ class rHPAccessor:
         """
         return self._apply_index_assign(
             wrapped_partial(rhp_py.rhp_to_center_child, res=resolution),
-            "rhp_center_child",
+            COLUMNS["center_child"],
         )
 
     def polyfill(
@@ -242,21 +250,21 @@ class rHPAccessor:
 
         # Need to wrap polyfill for each dataframe row so we can call it with geometry
         def func(row):
-            if not "geometry" in row.keys():
+            if not COLUMNS["geometry"] in row.keys():
                 return None
             else:
                 return rhp_py.polyfill(
-                    row.geometry, resolution, False, compress, verbose
+                    row[COLUMNS["geometry"]], resolution, False, compress, verbose
                 )
 
         # Polyfill cell sets for each row
         result = self._df.apply(func, axis=1)
 
         if not explode:
-            assign_args = {"rhp_polyfill": result}
+            assign_args = {COLUMNS["polyfill"]: result}
             return self._df.assign(**assign_args)
 
-        result = result.explode().to_frame("rhp_polyfill")
+        result = result.explode().to_frame(COLUMNS["polyfill"])
 
         return self._df.join(result)
 
@@ -272,9 +280,13 @@ class rHPAccessor:
         TODO: find out the meaning of unit "rads^2" that appears in h3pandas
         """
         return self._apply_index_assign(
-            wrapped_partial(rhp_py.cell_area, unit=unit), "rhp_cell_area"
+            wrapped_partial(rhp_py.cell_area, unit=unit), COLUMNS["cell_area"]
         )
 
+    def linetrace(self) -> AnyDataFrame:
+        raise NotImplementedError()
+
+    # Aggregate functions
     def geo_to_rhp_aggregate(
         self,
         resolution: int,
@@ -312,10 +324,14 @@ class rHPAccessor:
         geo_to_rhp : rHEALPix API method upon which this function builds
 
         """
-        colname = f"rhp_{resolution:02}" if resolution is not None else "rhp_parent"
+        colname = (
+            f"{COLUMNS['prefix']}{resolution:02}"
+            if resolution is not None
+            else COLUMNS["parent"]
+        )
         grouped = pd.DataFrame(
             self.geo_to_rhp(resolution, lat_col, lng_col, False)
-            .drop(columns=[lat_col, lng_col, "geometry"], errors="ignore")
+            .drop(columns=[lat_col, lng_col, COLUMNS["geometry"]], errors="ignore")
             .groupby(colname)
             .agg(operation)
         )
@@ -355,25 +371,69 @@ class rHPAccessor:
             for rhpaddress in self._df.index
         ]
         rhp_parent_column = (
-            f"rhp_{resolution:02}" if resolution is not None else "rhp_parent"
+            f"{COLUMNS['prefix']}{resolution:02}"
+            if resolution is not None
+            else COLUMNS["parent"]
         )
         kwargs_assign = {rhp_parent_column: parent_rhpaddresses}
         grouped = (
             self._df.assign(**kwargs_assign)
             .groupby(rhp_parent_column)[
-                [c for c in self._df.columns if c != "geometry"]
+                [c for c in self._df.columns if c != COLUMNS["geometry"]]
             ]
             .agg(operation)
         )
 
         return grouped.rhp.rhp_to_geo_boundary() if return_geometry else grouped
 
-    def polyfill_resample(self) -> AnyDataFrame:
-        raise NotImplementedError()
+    def polyfill_resample(
+        self,
+        resolution: int,
+        return_geometry: bool = True,
+        compress: bool = False,
+        verbose: bool = True,
+    ) -> AnyDataFrame:
+        """Experimental as stated in h3pandas, where this function comes from.
+        Currently essentially polyfill(..., explode=True) that sets the rHEALPix
+        index and adds the rHEALPix cell geometry if requested by return_geometry.
 
-    def linetrace(self) -> AnyDataFrame:
-        raise NotImplementedError()
+        Parameters
+        ----------
+        resolution : int
+            rHEALPix resolution
+        return_geometry: bool
+            (Optional) Whether to add a `geometry` column with the hexagonal cells.
+            Default = True
+        compress : bool
+            (Optional) Whether to compress cell groups that make up a parent cell
+            into the parent, returning 1 id instead of 9.
+            Default = False
 
+        Returns
+        -------
+        (Geo)DataFrame with rHEALPix cells with centroids within the input polygons.
+
+        See Also
+        --------
+        polyfill : rHEALPix API method upon which this method builds
+        """
+        result = self._df.rhp.polyfill(
+            resolution, explode=True, compress=compress, verbose=verbose
+        )
+        uncovered_rows = result[COLUMNS["polyfill"]].isna()
+        n_uncovered_rows = uncovered_rows.sum()
+        if verbose and (n_uncovered_rows > 0):
+            warn(
+                f"{n_uncovered_rows} rows did not generate a cell."
+                "Consider using a finer resolution."
+            )
+            result = result.loc[~uncovered_rows]
+
+        result = result.reset_index().set_index(COLUMNS["polyfill"])
+
+        return result.rhp.rhp_to_geo_boundary() if return_geometry else result
+
+    # Helper functions
     def _apply_index_assign(
         self,
         func: Callable,

--- a/rhppandas/util/const.py
+++ b/rhppandas/util/const.py
@@ -1,4 +1,5 @@
 COLUMNS = {
+    "prefix": "rhp_",
     "is_valid": "rhp_is_valid",
     "resolution": "rhp_resolution",
     "base_cell": "rhp_base_cell",

--- a/rhppandas/util/const.py
+++ b/rhppandas/util/const.py
@@ -1,0 +1,13 @@
+COLUMNS = {
+    "is_valid": "rhp_is_valid",
+    "resolution": "rhp_resolution",
+    "base_cell": "rhp_base_cell",
+    "parent": "rhp_parent",
+    "center_child": "rhp_center_child",
+    "cell_area": "rhp_cell_area",
+    "cell_ring": "rhp_cell_ring",
+    "k_ring": "rhp_k_ring",
+    "polyfill": "rhp_polyfill",
+    "linetrace": "rhp_linetrace",
+    "geometry": "geometry",
+}

--- a/tests/test_rhppandas.py
+++ b/tests/test_rhppandas.py
@@ -2,10 +2,12 @@ import pytest
 
 import pandas as pd
 import geopandas as gpd
+
 from geopandas.testing import assert_geodataframe_equal
 from shapely.geometry import box, Polygon
 
 from rhppandas import rhppandas
+from rhppandas.util.const import *
 from rhealpixdggs import rhp_wrappers as rhp_py
 
 pd.option_context("display.float_format", "{:0.15f}".format)
@@ -56,7 +58,7 @@ def basic_geodataframe_polygons():
 def indexed_dataframe(basic_dataframe):
     """DataFrame with lat, lng and resolution 9 rHEALPix index"""
     return basic_dataframe.assign(rhp_09=["N216055611", "N208542111"]).set_index(
-        "rhp_09"
+        f"{COLUMNS['prefix']}09"
     )
 
 
@@ -64,7 +66,7 @@ def indexed_dataframe(basic_dataframe):
 def indexed_dataframe_centre_cells(basic_dataframe):
     """DataFrame with lat, lng and resolution 10 rHEALPix index"""
     return basic_dataframe.assign(rhp_10=["N2160556114", "N2085421114"]).set_index(
-        "rhp_10"
+        f"{COLUMNS['prefix']}10"
     )
 
 
@@ -93,7 +95,7 @@ class TestGeoToRhp:
         result = basic_dataframe.rhp.geo_to_rhp(9)
         expected = basic_dataframe.assign(
             rhp_09=["N216055147", "N208518546"]
-        ).set_index("rhp_09")
+        ).set_index(f"{COLUMNS['prefix']}09")
 
         pd.testing.assert_frame_equal(expected, result)
 
@@ -101,7 +103,7 @@ class TestGeoToRhp:
         result = basic_geodataframe.rhp.geo_to_rhp(9)
         expected = basic_geodataframe.assign(
             rhp_09=["N216055147", "N208518546"]
-        ).set_index("rhp_09")
+        ).set_index(f"{COLUMNS['prefix']}09")
 
         pd.testing.assert_frame_equal(expected, result)
 
@@ -231,7 +233,7 @@ class TestKRing:
         ]
         expected = indexed_dataframe_centre_cells.assign(rhp_k_ring=expected_indices)
         result = indexed_dataframe_centre_cells.rhp.k_ring(verbose=False)
-        result["rhp_k_ring"] = result["rhp_k_ring"].apply(
+        result[COLUMNS["k_ring"]] = result[COLUMNS["k_ring"]].apply(
             set
         )  # Convert to set for testing
         pd.testing.assert_frame_equal(expected, result)
@@ -265,7 +267,7 @@ class TestKRing:
         )
         result = indexed_dataframe_centre_cells.rhp.k_ring(explode=True, verbose=False)
         assert len(result) == len(indexed_dataframe_centre_cells) * 9
-        assert set(result["rhp_k_ring"]) == expected_indices
+        assert set(result[COLUMNS["k_ring"]]) == expected_indices
         assert not result["lat"].isna().any()
 
 
@@ -409,7 +411,7 @@ class TestPolyfill:
         )
         result = rhp_geodataframe_with_values.rhp.polyfill(10, explode=True)
         assert len(result) == len(rhp_geodataframe_with_values) * 9
-        assert set(result["rhp_polyfill"]) == expected_indices
+        assert set(result[COLUMNS["polyfill"]]) == expected_indices
         assert not result["val"].isna().any()
 
     def test_polyfill_explode_unequal_lengths(self, basic_geodataframe_polygons):
@@ -419,7 +421,7 @@ class TestPolyfill:
         }
         result = basic_geodataframe_polygons.rhp.polyfill(4, explode=True)
         assert len(result) == 3
-        assert set(result["rhp_polyfill"]) == expected_indices
+        assert set(result[COLUMNS["polyfill"]]) == expected_indices
 
 
 class TestCellArea:
@@ -432,12 +434,19 @@ class TestCellArea:
         pd.testing.assert_frame_equal(expected, result)
 
 
+class TestLinetrace:
+    pass
+
+
+# Tests: Aggregate functions
 class TestGeoToRhpAggregate:
     def test_geo_to_rhp_aggregate(self, basic_dataframe_with_values):
         result = basic_dataframe_with_values.rhp.geo_to_rhp_aggregate(
             1, return_geometry=False
         )
-        expected = pd.DataFrame({"rhp_01": ["N2"], "val": [2 + 5]}).set_index("rhp_01")
+        expected = pd.DataFrame(
+            {f"{COLUMNS['prefix']}01": ["N2"], "val": [2 + 5]}
+        ).set_index(f"{COLUMNS['prefix']}01")
 
         pd.testing.assert_frame_equal(expected, result)
 
@@ -445,13 +454,17 @@ class TestGeoToRhpAggregate:
         result = basic_geodataframe_with_values.rhp.geo_to_rhp_aggregate(
             1, return_geometry=False
         )
-        expected = pd.DataFrame({"rhp_01": ["N2"], "val": [2 + 5]}).set_index("rhp_01")
+        expected = pd.DataFrame(
+            {f"{COLUMNS['prefix']}01": ["N2"], "val": [2 + 5]}
+        ).set_index(f"{COLUMNS['prefix']}01")
 
         pd.testing.assert_frame_equal(expected, result)
 
     def test_geo_to_rhp_aggregate_with_geometry(self, basic_dataframe_with_values):
         result = basic_dataframe_with_values.rhp.geo_to_rhp_aggregate(1)
-        indexed = pd.DataFrame({"rhp_01": ["N2"], "val": [2 + 5]}).set_index("rhp_01")
+        indexed = pd.DataFrame(
+            {f"{COLUMNS['prefix']}01": ["N2"], "val": [2 + 5]}
+        ).set_index(f"{COLUMNS['prefix']}01")
         geometry = [
             Polygon(rhp_py.rhp_to_geo_boundary(h, True, False)) for h in indexed.index
         ]
@@ -464,7 +477,7 @@ class TestRhpToParentAggregate:
     def test_rhp_to_parent_aggregate(self, rhp_geodataframe_with_values):
         result = rhp_geodataframe_with_values.rhp.rhp_to_parent_aggregate(8)
 
-        index = pd.Index(["N21605561"], name="rhp_08")
+        index = pd.Index(["N21605561"], name=f"{COLUMNS['prefix']}08")
         geometry = [Polygon(rhp_py.rhp_to_geo_boundary(h, True, False)) for h in index]
         expected = gpd.GeoDataFrame(
             {"val": [1 + 2 + 5]}, geometry=geometry, index=index, crs="epsg:4326"
@@ -476,15 +489,63 @@ class TestRhpToParentAggregate:
         result = rhp_dataframe_with_values.rhp.rhp_to_parent_aggregate(
             8, return_geometry=False
         )
-        index = pd.Index(["N21605561"], name="rhp_08")
+        index = pd.Index(["N21605561"], name=f"{COLUMNS['prefix']}08")
         expected = pd.DataFrame({"val": [1 + 2 + 5]}, index=index)
 
         pd.testing.assert_frame_equal(expected, result)
 
 
 class TestPolyfillResample:
-    pass
+    def test_polyfill_resample(self, rhp_geodataframe_with_values):
+        expected_indices = set().union(
+            *[
+                [
+                    "N2160556110",
+                    "N2160556111",
+                    "N2160556112",
+                    "N2160556113",
+                    "N2160556114",
+                    "N2160556115",
+                    "N2160556116",
+                    "N2160556117",
+                    "N2160556118",
+                ],
+                [
+                    "N2160556120",
+                    "N2160556121",
+                    "N2160556122",
+                    "N2160556123",
+                    "N2160556124",
+                    "N2160556125",
+                    "N2160556126",
+                    "N2160556127",
+                    "N2160556128",
+                ],
+                [
+                    "N2160556150",
+                    "N2160556151",
+                    "N2160556152",
+                    "N2160556153",
+                    "N2160556154",
+                    "N2160556155",
+                    "N2160556156",
+                    "N2160556157",
+                    "N2160556158",
+                ],
+            ]
+        )
+        expected_values = set([1, 2, 5])
+        result = rhp_geodataframe_with_values.rhp.polyfill_resample(
+            10, return_geometry=False
+        )
+        assert len(result) == len(rhp_geodataframe_with_values) * 9
+        assert set(result.index) == expected_indices
+        assert set(result["val"]) == expected_values
+        assert not result["val"].isna().any()
 
+    def test_polyfill_resample_uncovered_rows(self, basic_geodataframe_polygons):
+        basic_geodataframe_polygons.iloc[1] = box(0, 0, 3, 3)
+        with pytest.warns(UserWarning):
+            result = basic_geodataframe_polygons.rhp.polyfill_resample(2)
 
-class TestLinetrace:
-    pass
+        assert len(result) == 2

--- a/tests/test_rhppandas.py
+++ b/tests/test_rhppandas.py
@@ -544,8 +544,8 @@ class TestPolyfillResample:
         assert not result["val"].isna().any()
 
     def test_polyfill_resample_uncovered_rows(self, basic_geodataframe_polygons):
-        basic_geodataframe_polygons.iloc[1] = box(0, 0, 3, 3)
+        basic_geodataframe_polygons.iloc[1] = box(14, 50, 15, 53)
         with pytest.warns(UserWarning):
             result = basic_geodataframe_polygons.rhp.polyfill_resample(2)
 
-        assert len(result) == 2
+        assert len(result) == 0


### PR DESCRIPTION
Ported advanced feature `polyfill_resample` from `h3pandas` as it's used upstream in `vector2dggs`. It needed no unimplemented features from the rhealpixdggs backend, it's just a straightforward new function in the API.

I also took the opportunity to parametrise the column names used in the dataframes wherever I could.