### PR TITLE
demaion/crs warning

### DIFF
--- a/rhppandas/rhppandas.py
+++ b/rhppandas/rhppandas.py
@@ -34,6 +34,7 @@ class rHPAccessor:
         lat_col: str = "lat",
         lng_col: str = "lng",
         set_index: bool = True,
+        verbose: bool = True,
     ) -> AnyDataFrame:
         """
         Adds rHEALPix index to (Geo)DataFrame
@@ -54,6 +55,8 @@ class rHPAccessor:
         -------
         (Geo)DataFrame with rHEALPix addresses added
         """
+        if verbose:
+            self._crs_check_and_warn()
 
         # DataFrame wrangling
         if isinstance(self._df, gpd.GeoDataFrame):
@@ -77,7 +80,7 @@ class rHPAccessor:
             return df.set_index(colname)
         return df
 
-    def rhp_to_geo(self) -> gpd.GeoDataFrame:
+    def rhp_to_geo(self, verbose=True) -> gpd.GeoDataFrame:
         """Add `geometry` with centroid of each rHEALPix address to the DataFrame.
         Assumes rHEALPix index.
 
@@ -89,6 +92,9 @@ class rHPAccessor:
         --------
         rhp_to_geo_boundary : Adds an rHEALPix cell
         """
+        if verbose:
+            self._crs_check_and_warn()
+
         return self._apply_index_assign(
             wrapped_partial(rhp_py.rhp_to_geo, geo_json=True, plane=False),
             COLUMNS["geometry"],
@@ -98,13 +104,16 @@ class rHPAccessor:
             ),  # TODO: add correct coordinate system?
         )
 
-    def rhp_to_geo_boundary(self) -> AnyDataFrame:
+    def rhp_to_geo_boundary(self, verbose=True) -> AnyDataFrame:
         """Add `geometry` with rHEALPix squares to the DataFrame. Assumes rHEALPix index.
 
         Returns
         -------
         GeoDataFrame with rHEALPix geometry
         """
+        if verbose:
+            self._crs_check_and_warn()
+
         return self._apply_index_assign(
             wrapped_partial(rhp_py.rhp_to_geo_boundary, geo_json=True, plane=False),
             COLUMNS["geometry"],
@@ -128,11 +137,14 @@ class rHPAccessor:
         """
         return self._apply_index_assign(rhp_py.rhp_get_base_cell, COLUMNS["base_cell"])
 
-    def rhp_is_valid(self) -> AnyDataFrame:
+    def rhp_is_valid(self, verbose=True) -> AnyDataFrame:
         """
         Adds a column 'rhp_is_valid' indicating if the cell addresses are valid rHEALPix
         addresses or not.
         """
+        if verbose:
+            self._crs_check_and_warn()
+
         return self._apply_index_assign(rhp_py.rhp_is_valid, COLUMNS["is_valid"])
 
     def k_ring(
@@ -155,6 +167,7 @@ class rHPAccessor:
             to the k-ring cells
         """
         if verbose:
+            self._crs_check_and_warn()
             warn(str.format(rhp_py.CELL_RING_WARNING, "k"))
 
         func = wrapped_partial(rhp_py.k_ring, k=k, verbose=False)
@@ -177,6 +190,7 @@ class rHPAccessor:
         entries).
         """
         if verbose:
+            self._crs_check_and_warn()
             warn(str.format(rhp_py.CELL_RING_WARNING, "cell"))
 
         func = wrapped_partial(rhp_py.cell_ring, k=k, verbose=False)
@@ -247,6 +261,8 @@ class rHPAccessor:
             parent cell instead of the individual child addresses.
             Default: False
         """
+        if verbose:
+            self._crs_check_and_warn()
 
         # Need to wrap polyfill for each dataframe row so we can call it with geometry
         def func(row):
@@ -268,7 +284,9 @@ class rHPAccessor:
 
         return self._df.join(result)
 
-    def cell_area(self, unit: Literal["km^2", "m^2"] = "km^2") -> AnyDataFrame:
+    def cell_area(
+        self, unit: Literal["km^2", "m^2"] = "km^2", verbose: bool = True
+    ) -> AnyDataFrame:
         """
         Adds a column 'rhp_cell_area' to the dataframe of cells addresses.
         ----------
@@ -279,6 +297,9 @@ class rHPAccessor:
 
         TODO: find out the meaning of unit "rads^2" that appears in h3pandas
         """
+        if verbose:
+            self._crs_check_and_warn()
+
         return self._apply_index_assign(
             wrapped_partial(rhp_py.cell_area, unit=unit), COLUMNS["cell_area"]
         )
@@ -334,6 +355,7 @@ class rHPAccessor:
         lat_col: str = "lat",
         lng_col: str = "lng",
         return_geometry: bool = True,
+        verbose: bool = True,
     ) -> pd.DataFrame:
         """Adds rHEALPix index to DataFrame, groups points with the same index
         and performs `operation`.
@@ -370,19 +392,24 @@ class rHPAccessor:
             else COLUMNS["parent"]
         )
         grouped = pd.DataFrame(
-            self.geo_to_rhp(resolution, lat_col, lng_col, False)
+            self.geo_to_rhp(resolution, lat_col, lng_col, False, verbose)
             .drop(columns=[lat_col, lng_col, COLUMNS["geometry"]], errors="ignore")
             .groupby(colname)
             .agg(operation)
         )
 
-        return grouped.rhp.rhp_to_geo_boundary() if return_geometry else grouped
+        return (
+            grouped.rhp.rhp_to_geo_boundary(verbose=verbose)
+            if return_geometry
+            else grouped
+        )
 
     def rhp_to_parent_aggregate(
         self,
         resolution: int,
         operation: Union[dict, str, Callable] = "sum",
         return_geometry: bool = True,
+        verbose: bool = True,
     ) -> gpd.GeoDataFrame:
         """Assigns parent cell to each row, groups by it and performs `operation`.
         Assumes rHEALPix index.
@@ -424,7 +451,11 @@ class rHPAccessor:
             .agg(operation)
         )
 
-        return grouped.rhp.rhp_to_geo_boundary() if return_geometry else grouped
+        return (
+            grouped.rhp.rhp_to_geo_boundary(verbose=verbose)
+            if return_geometry
+            else grouped
+        )
 
     def polyfill_resample(
         self,

--- a/rhppandas/rhppandas.py
+++ b/rhppandas/rhppandas.py
@@ -303,6 +303,8 @@ class rHPAccessor:
         -------
         (Geo)DataFrame with rHEALPix cells with centroids within the input polygons.
         """
+        if verbose:
+            self._crs_check_and_warn()
 
         # Need to wrap linetrace for each dataframe row so we can call it with geometry
         def func(row):
@@ -544,3 +546,22 @@ class rHPAccessor:
         )
         result = self._df.join(result)
         return finalizer(result)
+
+    def _crs_check_and_warn(self):
+        """
+        rhppandas only supports coordinate system EPSG:4326 at the moment. This function checks
+        what coordinate system information is available and whether it matches what rhppandas
+        can provide.
+
+        Will print a warning that we assume EPSG:4326 if there is no coordinate system information
+        in the dataframe.
+
+        Will print a warning about incorrect results if a coordinate system other than EPSG:4326
+        is set.
+        """
+        if not hasattr(self._df, "crs"):
+            warn(WARNING_NO_CRS)
+        elif not self._df.crs:
+            warn(WARNING_CRS_NOT_SET)
+        elif self._df.crs.to_epsg() != 4326:
+            warn(str.format(WARNING_UNSUPPORTED_CRS, self._df.crs.to_epsg()))

--- a/rhppandas/util/const.py
+++ b/rhppandas/util/const.py
@@ -1,6 +1,6 @@
 WARNING_NO_CRS = "WARNING: No CRS information found in dataframe. Assuming EPSG:4326."
 WARNING_CRS_NOT_SET = "WARNING: CRS not set in GeoDataFrame. Assuming EPSG:4326."
-WARNING_UNSUPPORTED_CRS = "WARNING: GeoDataframe uses coordinate system {0} while rhppandas only supports EPSG:4326. Results will be inaccurate and best and unusable at worst."
+WARNING_UNSUPPORTED_CRS = "WARNING: GeoDataframe uses coordinate system {0} while rhppandas only supports EPSG:4326. Results will be inaccurate at best and unusable at worst."
 
 COLUMNS = {
     "prefix": "rhp_",

--- a/rhppandas/util/const.py
+++ b/rhppandas/util/const.py
@@ -1,5 +1,5 @@
-NOTE_NO_CRS = "NOTE: No CRS information found in dataframe. Assuming EPSG:4326."
-NOTE_CRS_NOT_SET = "NOTE: CRS not set in GeoDataFrame. Assuming EPSG:4326."
+WARNING_NO_CRS = "WARNING: No CRS information found in dataframe. Assuming EPSG:4326."
+WARNING_CRS_NOT_SET = "WARNING: CRS not set in GeoDataFrame. Assuming EPSG:4326."
 WARNING_UNSUPPORTED_CRS = "WARNING: GeoDataframe uses coordinate system {0} while rhppandas only supports EPSG:4326. Results will be inaccurate and best and unusable at worst."
 
 COLUMNS = {

--- a/rhppandas/util/const.py
+++ b/rhppandas/util/const.py
@@ -1,3 +1,7 @@
+NOTE_NO_CRS = "NOTE: No CRS information found in dataframe. Assuming EPSG:4326."
+NOTE_CRS_NOT_SET = "NOTE: CRS not set in GeoDataFrame. Assuming EPSG:4326."
+WARNING_UNSUPPORTED_CRS = "WARNING: GeoDataframe uses coordinate system {0} while rhppandas only supports EPSG:4326. Results will be inaccurate and best and unusable at worst."
+
 COLUMNS = {
     "prefix": "rhp_",
     "is_valid": "rhp_is_valid",

--- a/tests/test_rhppandas.py
+++ b/tests/test_rhppandas.py
@@ -124,7 +124,7 @@ def rhp_geodataframe_with_polyline_values(basic_geodataframe_linestring):
 # Tests: rHEALPix wrapper API
 class TestGeoToRhp:
     def test_geo_to_rhp(self, basic_dataframe):
-        result = basic_dataframe.rhp.geo_to_rhp(9)
+        result = basic_dataframe.rhp.geo_to_rhp(9, verbose=False)
         expected = basic_dataframe.assign(
             rhp_09=["N216055147", "N208518546"]
         ).set_index(f"{COLUMNS['prefix']}09")
@@ -150,7 +150,7 @@ class TestRhpToGeo:
         lngs = [14.000847727642311, 14.998138688394175]
         geometry = gpd.points_from_xy(x=lngs, y=lats, crs="epsg:4326")
         expected = gpd.GeoDataFrame(indexed_dataframe, geometry=geometry)
-        result = indexed_dataframe.rhp.rhp_to_geo()
+        result = indexed_dataframe.rhp.rhp_to_geo(verbose=False)
 
         assert_geodataframe_equal(expected, result, check_less_precise=True)
 
@@ -173,7 +173,7 @@ class TestRhpToGeoBoundary:
         )
         geometry = [Polygon(c1), Polygon(c2)]
 
-        result = indexed_dataframe.rhp.rhp_to_geo_boundary()
+        result = indexed_dataframe.rhp.rhp_to_geo_boundary(verbose=False)
         expected = gpd.GeoDataFrame(
             indexed_dataframe, geometry=geometry, crs="epsg:4326"
         )
@@ -190,7 +190,7 @@ class TestRhpToGeoBoundary:
         )
         geometry = [Polygon(c), Polygon()]
         indexed_dataframe.index = [str(indexed_dataframe.index[0])] + ["invalid"]
-        result = indexed_dataframe.rhp.rhp_to_geo_boundary()
+        result = indexed_dataframe.rhp.rhp_to_geo_boundary(verbose=False)
         expected = gpd.GeoDataFrame(
             indexed_dataframe, geometry=geometry, crs="epsg:4326"
         )
@@ -225,7 +225,7 @@ class TestRhpIsValid:
     def test_rhp_is_valid(self, indexed_dataframe):
         indexed_dataframe.index = [str(indexed_dataframe.index[0])] + ["invalid"]
         expected = indexed_dataframe.assign(rhp_is_valid=[True, False])
-        result = indexed_dataframe.rhp.rhp_is_valid()
+        result = indexed_dataframe.rhp.rhp_is_valid(verbose=False)
 
         pd.testing.assert_frame_equal(expected, result)
 
@@ -461,7 +461,7 @@ class TestCellArea:
         expected = indexed_dataframe.assign(
             rhp_cell_area=[0.258507625363534, 0.258507625363534]
         )
-        result = indexed_dataframe.rhp.cell_area()
+        result = indexed_dataframe.rhp.cell_area(verbose=False)
 
         pd.testing.assert_frame_equal(expected, result)
 
@@ -538,7 +538,7 @@ class TestLinetrace:
 class TestGeoToRhpAggregate:
     def test_geo_to_rhp_aggregate(self, basic_dataframe_with_values):
         result = basic_dataframe_with_values.rhp.geo_to_rhp_aggregate(
-            1, return_geometry=False
+            1, return_geometry=False, verbose=False
         )
         expected = pd.DataFrame(
             {f"{COLUMNS['prefix']}01": ["N2"], "val": [2 + 5]}
@@ -557,7 +557,7 @@ class TestGeoToRhpAggregate:
         pd.testing.assert_frame_equal(expected, result)
 
     def test_geo_to_rhp_aggregate_with_geometry(self, basic_dataframe_with_values):
-        result = basic_dataframe_with_values.rhp.geo_to_rhp_aggregate(1)
+        result = basic_dataframe_with_values.rhp.geo_to_rhp_aggregate(1, verbose=False)
         indexed = pd.DataFrame(
             {f"{COLUMNS['prefix']}01": ["N2"], "val": [2 + 5]}
         ).set_index(f"{COLUMNS['prefix']}01")
@@ -571,7 +571,9 @@ class TestGeoToRhpAggregate:
 
 class TestRhpToParentAggregate:
     def test_rhp_to_parent_aggregate(self, rhp_geodataframe_with_values):
-        result = rhp_geodataframe_with_values.rhp.rhp_to_parent_aggregate(8)
+        result = rhp_geodataframe_with_values.rhp.rhp_to_parent_aggregate(
+            8, verbose=False
+        )
 
         index = pd.Index(["N21605561"], name=f"{COLUMNS['prefix']}08")
         geometry = [Polygon(rhp_py.rhp_to_geo_boundary(h, True, False)) for h in index]

--- a/tests/test_rhppandas.py
+++ b/tests/test_rhppandas.py
@@ -645,3 +645,20 @@ class TestPolyfillResample:
             result = basic_geodataframe_polygons.rhp.polyfill_resample(2)
 
         assert len(result) == 0
+
+
+# Tests: Helper functions
+class TestCRSCheckAndWarn:
+    def test_crs_check_no_crs_field(self, basic_dataframe):
+        with pytest.warns(UserWarning):
+            basic_dataframe.rhp._crs_check_and_warn()
+
+    def test_crs_check_no_crs(self, basic_geodataframe):
+        basic_geodataframe.set_crs(crs=None, inplace=True, allow_override=True)
+        with pytest.warns(UserWarning):
+            basic_geodataframe.rhp._crs_check_and_warn()
+
+    def test_crs_check_wrong_crs(self, basic_geodataframe):
+        basic_geodataframe.set_crs(epsg=4272, inplace=True, allow_override=True)
+        with pytest.warns(UserWarning):
+            basic_geodataframe.rhp._crs_check_and_warn()


### PR DESCRIPTION
Added checks for missing or mismatched CRSs where cell geometries (as opposed to just cell addresses) are involved.

rhppandas only supports EPSG:4326, a GeoDataFrame can have its geometry in any number of other coordinate systems. Pure DataFrames, which are usually accepted as inputs, don't know about coordinates systems at all. But that doesn't mean that they're no use if their coordinate data conforms to EPSG:4326.

The check emits a warning in the following situations:
- There is no coordinate system field in the dataframe. The rhppandas API assumes EPSG:4326.
- There is no coordinate system set in the geodataframe The rhppandas API assumes EPSG:4326.
- The geodataframe has its CRS set to something other than EPSG:4326. The function emits a warning that the results will be wrong.

The check is wrapped in a helper function that's called by other parts of the API. The `verbose` flag of those functions controls if any warnings are emitted when anything's flagged up.